### PR TITLE
Added bountyhq

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,3 +358,7 @@ Credit Cards from Any Twitter Account](https://www.secgeek.net/twitter-vulnerabi
 - [SAML Bible](https://blog.netspi.com/attacking-sso-common-saml-vulnerabilities-ways-find/)
 - [Bypassing Google’s authentication to access their Internal Admin panels — Vishnu Prasad P G](https://medium.com/bugbountywriteup/bypassing-googles-fix-to-access-their-internal-admin-panels-12acd3d821e3)
 - [Smart Contract Vulnerabilities](http://www.dasp.co/)
+
+## Aggregators
+
+- [BountyHQ](https://bountyhq.secapps.com/) - compiles recon results from all bug-bounty programs


### PR DESCRIPTION
BountyHQ compiles results from all bug bounty programs and offers them for free as public dataset. It is a great starting point for getting into bug-bounties.